### PR TITLE
Add cursor plugin

### DIFF
--- a/corePlugins/cursor.js
+++ b/corePlugins/cursor.js
@@ -1,0 +1,4 @@
+import generator from '../util/generator';
+import theme from '../util/configHandler';
+
+export default generator.generateShadows('cursor', 'cursor', theme.cursor);

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -283,6 +283,15 @@ module.exports = {
       outline: '0 0 0 3px rgba(66, 153, 225, 0.5), 1.5',
       none: 'none',
     },
+    cursor: {
+      auto: 'auto',
+      default: 'default',
+      pointer: 'pointer',
+      wait: 'wait',
+      text: 'text',
+      move: 'move',
+      'not-allowed': 'not-allowed',
+    },
     flex: {
       '0': '0',
       '1': '1',


### PR DESCRIPTION
#22

Hi, here's my try at creating a cursor plugin.

The cursor properties can only be used with `react-native-web`.

Can you give me some guidance on how to run test this (both writing Jest test and run scripts to confirm what I'm doing works)? In other words, is there a `CONTRIBUTING` doc somewhere that can guide me through setting up the environment and how to start contirbuting?

Thanks @TVke for your work on this project!