### PR TITLE
Fix typo in margin-top in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ border-t-2 => t.borderT2
 
 A `-` in the beginning of a 'class' becomes a `_`.
 ```
--mt-2 => t._mt2
+-mt-2 => t._mT2
 ```
 
 A `/` also becomes a `_` to separate the numbers.


### PR DESCRIPTION
The direction should be uppercase, [as in the docs](https://tvke.github.io/react-native-tailwindcss/translations.html)